### PR TITLE
Formalize the binding-signature balance argument (algebraic core + range lift)

### DIFF
--- a/Zcash.lean
+++ b/Zcash.lean
@@ -5,4 +5,5 @@ import Zcash.Math.Groups
 import Zcash.Math.Curves
 import Zcash.Math.CtEdwards
 import Zcash.Proofs.Relations
+import Zcash.Security
 import Zcash.Tactic

--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -2,3 +2,5 @@
 -- Import modules here that should be built as part of the library.
 
 import Zcash.Security.BindingSignature.Balance
+import Zcash.Security.BindingSignature.Orchard
+import Zcash.Security.BindingSignature.Sapling

--- a/Zcash/Security.lean
+++ b/Zcash/Security.lean
@@ -1,0 +1,4 @@
+-- Security arguments for the Zcash protocol.
+-- Import modules here that should be built as part of the library.
+
+import Zcash.Security.BindingSignature.Balance

--- a/Zcash/Security/BindingSignature/Balance.lean
+++ b/Zcash/Security/BindingSignature/Balance.lean
@@ -41,8 +41,10 @@ binding hypothesis. Instead we phrase binding as a **reduction**:
 * **Discrete-log-relation hardness** — discharges the reduction above to actual balance; lives in
   the computational/AGM layer (not yet built).
 * **Lifting `A = 0` in `F = ZMod r` to integer balance** (`∑ v_in = ∑ v_out + v_balance` over ℤ) —
-  the range / no-overflow argument (`intBalance_eq_zero_of_lt`, valid when `MAX_MONEY · maxActions <
-  r`); wiring it to the homomorphic-sum layer is the remaining piece.
+  the range / no-overflow argument (`intBalance_eq_zero_of_lt`, valid when `|vSum| < r`, which the
+  spec's §4.13 / §4.14 range argument establishes from the 64-bit value/balance types and the bound
+  on the spend/output/action count — see `§ Integer balance` below); wiring it to the homomorphic-sum
+  layer is the remaining piece.
 -/
 
 namespace Zcash.Security.BindingSignature
@@ -120,10 +122,41 @@ theorem value_coeff_zero (V R bvk : M) (A B bsk : F)
 
 `value_coeff_zero` (and the group-faithful reduction) conclude `A = 0` in `F = ZMod r` — balance
 *modulo the scalar-field order*. Genuine balance is the integer equation
-`∑ v_in − ∑ v_out − v_balance = 0`. The two coincide because note values and `v_balance` are bounded,
-so the integer balance cannot wrap mod `r`: with note values in `[0, MAX_MONEY]` and at most
-`maxActions` of them, the integer balance `N` has `N.natAbs < r` whenever `MAX_MONEY · maxActions < r`
-— comfortably true for Pasta (`r ≈ 2^254`, `MAX_MONEY ≈ 2^51`). The lift is then pure arithmetic. -/
+`∑ v_in − ∑ v_out − v_balance = 0`. The two coincide exactly as in the spec's argument (§4.13 / §4.14,
+the paragraph beginning "The preceding argument shows only that `vSum = 0 (mod r)`; … we will also
+demonstrate that it does not overflow `ValueCommitType`"): the net value `vSum` cannot wrap mod `r`,
+because each note value is range-proven and the spend/output/action count is bounded, so
+`vSum ∈ ValueCommitType = [−(r−1)/2, (r−1)/2] ⊂ (−r, r)` and `vSum = 0 (mod r)` forces `vSum = 0` over ℤ.
+The argument deliberately uses the *value-type* range — **not** `MAX_MONEY`; it works for any
+signed-64-bit `valueBalance`, which is all the encoding constrains.
+
+The precise bounds differ between the pools, and turn on note values being *unsigned* 64-bit while
+value balances are *signed* 64-bit:
+
+* **Sapling (§4.13).** The Spend statements prove each spend value `v_old_i ∈ ValueType = {0 .. 2^64 − 1}`
+  and the Output statements prove each output value `v_new_j ∈ ValueType`; `vBalance` is a signed
+  two's-complement 64-bit integer in `SignedValueFieldType = [−2^63, 2^63 − 1]`. With
+  `vSum = ∑ v_old_i − ∑ v_new_j − vBalance` this gives `vSum ∈ [−m · (2^64 − 1) − 2^63 + 1, n · (2^64 − 1) + 2^63]`.
+  The action count is bounded *indirectly*, via the 2 MB transaction-size limit against the minimum
+  per-description sizes (a v5 spend ≥ 352 bytes, an output ≥ 948 bytes): `n ≤ ⌊2000000/352⌋ = 5681`
+  spends and `m ≤ ⌊2000000/948⌋ = 2109` outputs.
+
+* **Orchard (§4.14).** Each action performs *both* a spend and an output, committing to the *net*
+  value `v_net_i = v_spend − v_output` — a difference of two unsigned 64-bit note values, hence
+  range-proven (by the Action statement) to lie in `SignedValueDifferenceType = [−2^64 + 1, 2^64 − 1]`
+  (signed, unlike Sapling's unsigned per-note `ValueType`). With `vSum = ∑ v_net_i − vBalance` and the
+  same signed-64-bit `vBalance` this gives `vSum ∈ [−n · (2^64 − 1) − 2^63 + 1, n · (2^64 − 1) + 2^63]`
+  — a *single* `n`, since each action contributes one net term. Here the action count is bounded
+  *directly* by a dedicated consensus rule `n ≤ 2^16 − 1`, independent of the block size — more elegant
+  than Sapling's size-derived bound. (The spec notes this rule is technically redundant given the 2 MB
+  transaction-size limit, but it suffices on its own.)
+
+Either way `vSum ∈ ValueCommitType ⊂ (−r, r)`.
+
+**Caveat — this range argument is not yet formalized, only described here.** `intBalance_eq_zero_of_lt`
+*assumes* `N.natAbs < r`; discharging that from the per-note / per-action 64-bit range bounds (proven by
+the Spend/Output/Action statements) and the action-count bound, at the concrete `r`, is a remaining
+piece. Given the bound, the lift itself is pure arithmetic. -/
 
 /-- No-overflow lift: an integer reducing to `0` mod `r` whose magnitude is `< r` is `0`. This turns
 balance modulo the scalar-field order (`A = 0` in `ZMod r`) into integer balance, given the value
@@ -199,9 +232,12 @@ theorem bundle_mod_balances (V R : M) (spends outputs : List (F × F)) (vBalance
 
 /-- **Integer value balance** — the second stage of the spec §4.13 / §4.14 argument. Stage 1
 (`bundle_mod_balances`) gives `A = 0` in `ZMod r`, i.e. balance *modulo the scalar-field order*. When
-that `A` is the reduction of an integer net value `N` that cannot wrap (`|N| < r`, guaranteed by
-`MAX_MONEY · maxActions < r`), the range / no-overflow lift `intBalance_eq_zero_of_lt` upgrades it to
-`N = 0` over ℤ — genuine integer value balance. -/
+that `A` is the reduction of an integer net value `N = vSum` that cannot wrap (`|N| < r`), the range /
+no-overflow lift `intBalance_eq_zero_of_lt` upgrades it to `N = 0` over ℤ — genuine integer value
+balance. The bound `|N| < r` is the `hbound` hypothesis here; what justifies it is the spec's range
+argument (`§ Integer balance` above) — the unsigned-64-bit note values / signed-64-bit `valueBalance`
+together with the spend/output/action-count bound put `vSum ∈ ValueCommitType ⊂ (−r, r)` — but that
+derivation is itself not yet formalized. -/
 theorem bundle_integer_balances {r : ℕ} [Fact (Nat.Prime r)]
     {M : Type*} [AddCommGroup M] [Module (ZMod r) M]
     (V R : M) (spends outputs : List (ZMod r × ZMod r)) (vBalance bsk : ZMod r) (N : ℤ)

--- a/Zcash/Security/BindingSignature/Balance.lean
+++ b/Zcash/Security/BindingSignature/Balance.lean
@@ -147,4 +147,72 @@ theorem intBalance_eq_zero_of_abs_lt {r : ℕ} [NeZero r] (N : ℤ)
   apply intBalance_eq_zero_of_lt N hmod
   rwa [Int.abs_eq_natAbs, Nat.cast_lt] at hlt
 
+/-! ### Deriving the decomposition from a bundle (homomorphic value commitments)
+
+The hypothesis `bvk = A • V + B • R` consumed above is not an assumption: it is *derived* from the
+homomorphic value commitment `cv v rcv = v • V + rcv • R` and the shape of a bundle — lists of
+spend / output `(value, randomness)` pairs together with the declared `vBalance`. -/
+
+/-- The value commitment `cv v rcv = v • V + rcv • R`. -/
+def valueCommit (V R : M) (v rcv : F) : M := v • V + rcv • R
+
+/-- A sum of value commitments decomposes as the value-sum times `V` plus the randomness-sum times
+`R` — the homomorphic property. -/
+theorem sum_valueCommit (V R : M) (l : List (F × F)) :
+    (l.map fun p => valueCommit V R p.1 p.2).sum
+      = (l.map Prod.fst).sum • V + (l.map Prod.snd).sum • R := by
+  induction l with
+  | nil => simp
+  | cons a l ih =>
+    simp only [List.map_cons, List.sum_cons, ih]
+    simp only [valueCommit, add_smul]
+    abel
+
+/-- The binding verification key of a bundle: sum of spend commitments minus sum of output
+commitments minus `vBalance • V`. -/
+def bindingVK (V R : M) (spends outputs : List (F × F)) (vBalance : F) : M :=
+  (spends.map fun p => valueCommit V R p.1 p.2).sum
+    - (outputs.map fun p => valueCommit V R p.1 p.2).sum - vBalance • V
+
+/-- **`hSum`, derived.** The binding verification key decomposes homomorphically as `A • V + B • R`,
+with `A` the net value (`∑ spend values − ∑ output values − vBalance`) and `B` the net randomness
+(`∑ spend randomness − ∑ output randomness`). -/
+theorem bindingVK_decomp (V R : M) (spends outputs : List (F × F)) (vBalance : F) :
+    bindingVK V R spends outputs vBalance
+      = ((spends.map Prod.fst).sum - (outputs.map Prod.fst).sum - vBalance) • V
+        + ((spends.map Prod.snd).sum - (outputs.map Prod.snd).sum) • R := by
+  rw [bindingVK, sum_valueCommit, sum_valueCommit]
+  simp only [sub_smul]
+  abel
+
+/-- Putting it together: for a bundle whose binding signature verifies (RedDSA extractability gives
+`bvk = bsk • R`) and under (idealized) binding, the net value coefficient is zero **in `F`** — i.e.
+balance *modulo the scalar-field order*, with no `hSum` assumption (the decomposition is derived by
+`bindingVK_decomp`). This is **not** integer balance: lifting it to `∑ v_in = ∑ v_out + v_balance`
+over ℤ needs the range / no-overflow step `intBalance_eq_zero_of_lt`, which is not applied here. -/
+theorem bundle_mod_balances (V R : M) (spends outputs : List (F × F)) (vBalance bsk : F)
+    (hbind : Binding (F := F) V R)
+    (hExtract : bindingVK V R spends outputs vBalance = bsk • R) :
+    (spends.map Prod.fst).sum - (outputs.map Prod.fst).sum - vBalance = 0 :=
+  value_coeff_zero V R (bindingVK V R spends outputs vBalance) _ _ bsk hbind hExtract
+    (bindingVK_decomp V R spends outputs vBalance)
+
+/-- **Integer value balance** — the second stage of the spec §4.13 / §4.14 argument. Stage 1
+(`bundle_mod_balances`) gives `A = 0` in `ZMod r`, i.e. balance *modulo the scalar-field order*. When
+that `A` is the reduction of an integer net value `N` that cannot wrap (`|N| < r`, guaranteed by
+`MAX_MONEY · maxActions < r`), the range / no-overflow lift `intBalance_eq_zero_of_lt` upgrades it to
+`N = 0` over ℤ — genuine integer value balance. -/
+theorem bundle_integer_balances {r : ℕ} [Fact (Nat.Prime r)]
+    {M : Type*} [AddCommGroup M] [Module (ZMod r) M]
+    (V R : M) (spends outputs : List (ZMod r × ZMod r)) (vBalance bsk : ZMod r) (N : ℤ)
+    (hcast : (spends.map Prod.fst).sum - (outputs.map Prod.fst).sum - vBalance = (N : ZMod r))
+    (hbound : N.natAbs < r)
+    (hbind : Binding (F := ZMod r) V R)
+    (hExtract : bindingVK V R spends outputs vBalance = bsk • R) :
+    N = 0 := by
+  haveI : NeZero r := ⟨(Fact.out : Nat.Prime r).pos.ne'⟩
+  refine intBalance_eq_zero_of_lt N ?_ hbound
+  rw [← hcast]
+  exact bundle_mod_balances V R spends outputs vBalance bsk hbind hExtract
+
 end Zcash.Security.BindingSignature

--- a/Zcash/Security/BindingSignature/Balance.lean
+++ b/Zcash/Security/BindingSignature/Balance.lean
@@ -40,8 +40,9 @@ binding hypothesis. Instead we phrase binding as a **reduction**:
   proved (its proof needs a random oracle + forking); supplied as the `hExtract` hypothesis.
 * **Discrete-log-relation hardness** — discharges the reduction above to actual balance; lives in
   the computational/AGM layer (not yet built).
-* **Lifting `A = 0` in `F = ZMod r` to integer balance** (`∑ v_in = ∑ v_out + v_balance` over ℤ)
-  via a range / no-overflow argument (`MAX_MONEY · maxActions < r / 2`) — not yet done.
+* **Lifting `A = 0` in `F = ZMod r` to integer balance** (`∑ v_in = ∑ v_out + v_balance` over ℤ) —
+  the range / no-overflow argument (`intBalance_eq_zero_of_lt`, valid when `MAX_MONEY · maxActions <
+  r`); wiring it to the homomorphic-sum layer is the remaining piece.
 -/
 
 namespace Zcash.Security.BindingSignature
@@ -114,5 +115,36 @@ theorem value_coeff_zero (V R bvk : M) (A B bsk : F)
     A = 0 :=
   balances_of_binding V R A B bsk hbind
     (smul_value_eq_smul_rand V R bvk A B bsk hExtract hSum)
+
+/-! ### Integer balance: range / no-overflow lift
+
+`value_coeff_zero` (and the group-faithful reduction) conclude `A = 0` in `F = ZMod r` — balance
+*modulo the scalar-field order*. Genuine balance is the integer equation
+`∑ v_in − ∑ v_out − v_balance = 0`. The two coincide because note values and `v_balance` are bounded,
+so the integer balance cannot wrap mod `r`: with note values in `[0, MAX_MONEY]` and at most
+`maxActions` of them, the integer balance `N` has `N.natAbs < r` whenever `MAX_MONEY · maxActions < r`
+— comfortably true for Pasta (`r ≈ 2^254`, `MAX_MONEY ≈ 2^51`). The lift is then pure arithmetic. -/
+
+/-- No-overflow lift: an integer reducing to `0` mod `r` whose magnitude is `< r` is `0`. This turns
+balance modulo the scalar-field order (`A = 0` in `ZMod r`) into integer balance, given the value
+sums cannot wrap. -/
+theorem intBalance_eq_zero_of_lt {r : ℕ} [NeZero r] (N : ℤ)
+    (hmod : (N : ZMod r) = 0) (hlt : N.natAbs < r) : N = 0 := by
+  obtain ⟨k, rfl⟩ := (ZMod.intCast_zmod_eq_zero_iff_dvd N r).mp hmod
+  rcases eq_or_ne k 0 with hk | hk
+  · simp [hk]
+  · have hpos : 0 < k.natAbs := Int.natAbs_pos.mpr hk
+    have habs : ((r : ℤ) * k).natAbs = r * k.natAbs := by simp [Int.natAbs_mul]
+    rw [habs] at hlt
+    have hle : r ≤ r * k.natAbs := by
+      calc r = r * 1 := (Nat.mul_one r).symm
+        _ ≤ r * k.natAbs := Nat.mul_le_mul (le_refl r) hpos
+    omega
+
+/-- The same lift phrased with an integer absolute-value bound `|N| < r`. -/
+theorem intBalance_eq_zero_of_abs_lt {r : ℕ} [NeZero r] (N : ℤ)
+    (hmod : (N : ZMod r) = 0) (hlt : |N| < (r : ℤ)) : N = 0 := by
+  apply intBalance_eq_zero_of_lt N hmod
+  rwa [Int.abs_eq_natAbs, Nat.cast_lt] at hlt
 
 end Zcash.Security.BindingSignature

--- a/Zcash/Security/BindingSignature/Balance.lean
+++ b/Zcash/Security/BindingSignature/Balance.lean
@@ -1,0 +1,118 @@
+import Mathlib
+
+/-!
+# Binding-signature balance: shared algebraic core
+
+This module formalizes the algebraic heart of the Zcash binding-signature *balance* argument
+(Zcash protocol specification §4.13 Sapling / §4.14 Orchard), abstracted over an arbitrary
+`F`-module `M` so that it applies to both the Jubjub (Sapling) and Pallas (Orchard)
+value-commitment groups. Here `F` will be instantiated with the scalar field `ZMod r`.
+
+## The setting
+
+Value commitments are `cv v rcv = v • V + rcv • R` for fixed generators `V` (value base) and
+`R` (randomness base). For a bundle, the binding verification key is
+`bvk = (∑ spend cv) − (∑ output cv) − v_balance • V`, which by homomorphicity equals
+`A • V + B • R`, where `A = ∑ v_in − ∑ v_out − v_balance` and `B = ∑ rcv_in − ∑ rcv_out`.
+
+## How binding is expressed (and why not as "no relation exists")
+
+In a prime-order group, `V` and `R` are *always* discrete-log-related — a nontrivial `(a,b)` with
+`a • V + b • R = 0` exists; you simply cannot *find* it. So the information-theoretic statement
+"the only relation is trivial" is **false** in the group setting and must not be used as the
+binding hypothesis. Instead we phrase binding as a **reduction**:
+
+* `§ Group-faithful` below proves, with *no* cryptographic hypothesis, that a non-balancing
+  verifying bundle **exhibits** an explicit nontrivial relation between `V` and `R`
+  (`relation_of_imbalance`), equivalently the discrete log `dlog_R V` (`rand_log_of_imbalance`).
+  "The bundle balances" is then the *contrapositive under discrete-log-relation hardness* — a
+  statement about efficient adversaries, supplied by the algebraic group model or a DLR-hardness
+  assumption at the computational layer. This is the shape of the spec's argument: *if you can
+  unbalance, you can solve DL.*
+
+* `§ Abstract model` keeps the information-theoretic `Binding` predicate, but only as a sanity
+  check over a *general* `F`-module where `V, R` genuinely can be independent (e.g. a rank-≥2 free
+  module). It is **not** the group assumption and is never instantiated at a prime-order group.
+
+## Assumptions / later steps
+
+* **RedDSA extractability** (`bvk = bsk • R` from a verifying binding signature) — assumed, not
+  proved (its proof needs a random oracle + forking); supplied as the `hExtract` hypothesis.
+* **Discrete-log-relation hardness** — discharges the reduction above to actual balance; lives in
+  the computational/AGM layer (not yet built).
+* **Lifting `A = 0` in `F = ZMod r` to integer balance** (`∑ v_in = ∑ v_out + v_balance` over ℤ)
+  via a range / no-overflow argument (`MAX_MONEY · maxActions < r / 2`) — not yet done.
+-/
+
+namespace Zcash.Security.BindingSignature
+
+variable {F : Type*} [Field F]
+variable {M : Type*} [AddCommGroup M] [Module F M]
+
+/-- From RedDSA extractability (`bvk = bsk • R`) and the homomorphic decomposition of the binding
+verification key (`bvk = A • V + B • R`), the value coefficient satisfies `A • V = (bsk − B) • R`.
+True unconditionally (pure module algebra). -/
+theorem smul_value_eq_smul_rand (V R bvk : M) (A B bsk : F)
+    (hExtract : bvk = bsk • R) (hSum : bvk = A • V + B • R) :
+    A • V = (bsk - B) • R := by
+  have h : A • V + B • R = bsk • R := by rw [← hSum, hExtract]
+  calc A • V = bsk • R - B • R := eq_sub_of_add_eq h
+    _ = (bsk - B) • R := (sub_smul bsk B R).symm
+
+/-! ### Group-faithful reduction (no cryptographic hypothesis; true in a prime-order group) -/
+
+/-- **The group-faithful binding reduction.** A non-balancing (`A ≠ 0`) verifying bundle *exhibits*
+an explicit nontrivial discrete-log relation between the value base `V` and the randomness base `R`:
+the coefficients `(A, B − bsk)` are not both zero (indeed `A ≠ 0`) and `A • V + (B − bsk) • R = 0`.
+Such a relation always exists in the group; the content is that imbalance *produces* one — which,
+under discrete-log-relation hardness, cannot happen, so the bundle balances. -/
+theorem relation_of_imbalance (V R bvk : M) (A B bsk : F)
+    (hA : A ≠ 0)
+    (hExtract : bvk = bsk • R) (hSum : bvk = A • V + B • R) :
+    A ≠ 0 ∧ A • V + (B - bsk) • R = 0 := by
+  refine ⟨hA, ?_⟩
+  rw [smul_value_eq_smul_rand V R bvk A B bsk hExtract hSum, ← add_smul]
+  have hc : (bsk - B) + (B - bsk) = (0 : F) := by ring
+  rw [hc, zero_smul]
+
+/-- Equivalent explicit form of `relation_of_imbalance`: a non-balancing verifying bundle yields the
+discrete log of `V` base `R`, namely `dlog_R V = A⁻¹ (bsk − B)`. This is the constructive extraction
+the AGM / DLR wrappers feed to discrete-log hardness. -/
+theorem rand_log_of_imbalance (V R bvk : M) (A B bsk : F) (hA : A ≠ 0)
+    (hExtract : bvk = bsk • R) (hSum : bvk = A • V + B • R) :
+    V = (A⁻¹ * (bsk - B)) • R := by
+  have hVR := smul_value_eq_smul_rand V R bvk A B bsk hExtract hSum
+  have h : A⁻¹ • (A • V) = A⁻¹ • ((bsk - B) • R) := by rw [hVR]
+  rwa [smul_smul, smul_smul, inv_mul_cancel₀ hA, one_smul] at h
+
+/-! ### Abstract model (sanity check over a general module; NOT the group assumption)
+
+The information-theoretic binding predicate below is satisfiable only when `V` and `R` are genuinely
+independent — e.g. in a free `F`-module of rank ≥ 2. It validates the algebra of the reduction but
+is **false** in a prime-order group and is never instantiated there; the group uses
+`relation_of_imbalance` + DLR-hardness instead. -/
+
+/-- Information-theoretic binding: the only `F`-linear relation between `V` and `R` is trivial.
+Satisfiable only in rank-≥2 models; false in a cyclic group. -/
+def Binding (V R : M) : Prop := ∀ a b : F, a • V + b • R = 0 → a = 0 ∧ b = 0
+
+/-- In an abstract model where `Binding` holds, a verifying bundle balances in `F`. -/
+theorem balances_of_binding (V R : M) (A B bsk : F)
+    (hbind : Binding (F := F) V R)
+    (hVR : A • V = (bsk - B) • R) :
+    A = 0 := by
+  have h0 : A • V + (B - bsk) • R = 0 := by
+    rw [hVR, ← add_smul]
+    have hc : (bsk - B) + (B - bsk) = (0 : F) := by ring
+    rw [hc, zero_smul]
+  exact (hbind A (B - bsk) h0).1
+
+/-- Abstract-model combination: extractability + decomposition + (idealized) binding ⟹ `A = 0`. -/
+theorem value_coeff_zero (V R bvk : M) (A B bsk : F)
+    (hbind : Binding (F := F) V R)
+    (hExtract : bvk = bsk • R) (hSum : bvk = A • V + B • R) :
+    A = 0 :=
+  balances_of_binding V R A B bsk hbind
+    (smul_value_eq_smul_rand V R bvk A B bsk hExtract hSum)
+
+end Zcash.Security.BindingSignature

--- a/Zcash/Security/BindingSignature/Balance.lean
+++ b/Zcash/Security/BindingSignature/Balance.lean
@@ -40,11 +40,13 @@ binding hypothesis. Instead we phrase binding as a **reduction**:
   proved (its proof needs a random oracle + forking); supplied as the `hExtract` hypothesis.
 * **Discrete-log-relation hardness** — discharges the reduction above to actual balance; lives in
   the computational/AGM layer (not yet built).
-* **Lifting `A = 0` in `F = ZMod r` to integer balance** (`∑ v_in = ∑ v_out + v_balance` over ℤ) —
-  the range / no-overflow argument (`intBalance_eq_zero_of_lt`, valid when `|vSum| < r`, which the
-  spec's §4.13 / §4.14 range argument establishes from the 64-bit value/balance types and the bound
-  on the spend/output/action count — see `§ Integer balance` below); wiring it to the homomorphic-sum
-  layer is the remaining piece.
+* **Lifting `A = 0` in `F = ZMod r` to integer balance** (`∑ v_in = ∑ v_out + v_balance` over ℤ) — the
+  range / no-overflow lift `intBalance_eq_zero_of_lt`, valid when `|vSum| < r`. That bound follows from
+  the 64-bit value/balance types and the spend/output/action-count bound; the per-pool lemmas
+  `orchard_natAbs_lt` / `sapling_natAbs_lt` (modules `Orchard` / `Sapling`) establish it (see also
+  `§ Integer balance` below). The open step is the plumbing: wiring those lemmas, and the
+  integer→scalar-field cast `hcast`, into `bundle_integer_balances` so the value-type hypotheses are
+  consumed end-to-end.
 -/
 
 namespace Zcash.Security.BindingSignature
@@ -138,8 +140,9 @@ value balances are *signed* 64-bit:
   two's-complement 64-bit integer in `SignedValueFieldType = [−2^63, 2^63 − 1]`. With
   `vSum = ∑ v_old_i − ∑ v_new_j − vBalance` this gives `vSum ∈ [−m · (2^64 − 1) − 2^63 + 1, n · (2^64 − 1) + 2^63]`.
   The action count is bounded *indirectly*, via the 2 MB transaction-size limit against the minimum
-  per-description sizes (a v5 spend ≥ 352 bytes, an output ≥ 948 bytes): `n ≤ ⌊2000000/352⌋ = 5681`
-  spends and `m ≤ ⌊2000000/948⌋ = 2109` outputs.
+  per-description sizes — a spend is ≥ 384 bytes (v4) or ≥ 352 bytes (v5, where the per-spend `anchor`
+  becomes transaction-wide), an output ≥ 948 bytes — giving `n ≤ ⌊2000000/384⌋ = 5208` (v4) or
+  `⌊2000000/352⌋ = 5681` (v5) spends and `m ≤ ⌊2000000/948⌋ = 2109` outputs.
 
 * **Orchard (§4.14).** Each action performs *both* a spend and an output, committing to the *net*
   value `v_net_i = v_spend − v_output` — a difference of two unsigned 64-bit note values, hence
@@ -153,10 +156,11 @@ value balances are *signed* 64-bit:
 
 Either way `vSum ∈ ValueCommitType ⊂ (−r, r)`.
 
-**Caveat — this range argument is not yet formalized, only described here.** `intBalance_eq_zero_of_lt`
-*assumes* `N.natAbs < r`; discharging that from the per-note / per-action 64-bit range bounds (proven by
-the Spend/Output/Action statements) and the action-count bound, at the concrete `r`, is a remaining
-piece. Given the bound, the lift itself is pure arithmetic. -/
+The per-pool lemmas `orchard_natAbs_lt` and `sapling_natAbs_lt` (with `_v4` / `_v5` corollaries) in the
+`Orchard` / `Sapling` modules derive `N.natAbs < r` from the per-note / per-action 64-bit range proofs
+(hypotheses standing in for the Spend/Output/Action statements' Halo2 range proofs), the
+field-size-derived action-count bounds, and the field order — producing the `hbound` consumed by
+`bundle_integer_balances`. -/
 
 /-- No-overflow lift: an integer reducing to `0` mod `r` whose magnitude is `< r` is `0`. This turns
 balance modulo the scalar-field order (`A = 0` in `ZMod r`) into integer balance, given the value
@@ -235,9 +239,10 @@ theorem bundle_mod_balances (V R : M) (spends outputs : List (F × F)) (vBalance
 that `A` is the reduction of an integer net value `N = vSum` that cannot wrap (`|N| < r`), the range /
 no-overflow lift `intBalance_eq_zero_of_lt` upgrades it to `N = 0` over ℤ — genuine integer value
 balance. The bound `|N| < r` is the `hbound` hypothesis here; what justifies it is the spec's range
-argument (`§ Integer balance` above) — the unsigned-64-bit note values / signed-64-bit `valueBalance`
-together with the spend/output/action-count bound put `vSum ∈ ValueCommitType ⊂ (−r, r)` — but that
-derivation is itself not yet formalized. -/
+argument — the unsigned-64-bit note values / signed-64-bit `valueBalance` together with the
+spend/output/action-count bound put `vSum ∈ ValueCommitType ⊂ (−r, r)`. The per-pool lemmas
+`orchard_natAbs_lt` / `sapling_natAbs_lt` (modules `…BindingSignature.Orchard` / `.Sapling`) establish
+this bound from the value-type range proofs, producing the `hbound` consumed here. -/
 theorem bundle_integer_balances {r : ℕ} [Fact (Nat.Prime r)]
     {M : Type*} [AddCommGroup M] [Module (ZMod r) M]
     (V R : M) (spends outputs : List (ZMod r × ZMod r)) (vBalance bsk : ZMod r) (N : ℤ)
@@ -250,5 +255,40 @@ theorem bundle_integer_balances {r : ℕ} [Fact (Nat.Prime r)]
   refine intBalance_eq_zero_of_lt N ?_ hbound
   rw [← hcast]
   exact bundle_mod_balances V R spends outputs vBalance bsk hbind hExtract
+
+/-! ### Generic integer-range helpers for the no-overflow lift
+
+These discharge the `hbound`/`hlt` hypothesis of the lifts above from value-type range bounds. The
+Orchard- and Sapling-specific instances — the concrete byte / action-count bounds, the `vSum` range
+constants, and the field orders — live in `Zcash.Security.BindingSignature.Orchard` and `.Sapling`. -/
+
+/-- Triangle bound for a list sum: if every element has `|x| ≤ M`, the sum has `|∑| ≤ length · M`. -/
+theorem abs_listSum_le {l : List ℤ} {M : ℤ} (h : ∀ x ∈ l, |x| ≤ M) :
+    |l.sum| ≤ (l.length : ℤ) * M := by
+  induction l with
+  | nil => simp
+  | cons a t ih =>
+    have ha : |a| ≤ M := h a List.mem_cons_self
+    have ht : |t.sum| ≤ (t.length : ℤ) * M := ih fun x hx => h x (List.mem_cons_of_mem a hx)
+    calc |(a :: t).sum| = |a + t.sum| := by rw [List.sum_cons]
+      _ ≤ |a| + |t.sum| := abs_add_le a t.sum
+      _ ≤ M + (t.length : ℤ) * M := add_le_add ha ht
+      _ = ((a :: t).length : ℤ) * M := by rw [List.length_cons]; push_cast; ring
+
+/-- From a magnitude bound `|N| ≤ B` and the field-order gap `B < r`, the residue `N.natAbs < r`
+(symmetric form — used by Orchard, whose net values are signed). -/
+theorem natAbs_lt_of_abs_le {r : ℕ} {N B : ℤ} (hN : |N| ≤ B) (hr : B < (r : ℤ)) :
+    N.natAbs < r := by
+  have h : (N.natAbs : ℤ) < (r : ℤ) := by rw [← Int.abs_eq_natAbs]; exact lt_of_le_of_lt hN hr
+  exact_mod_cast h
+
+/-- Two-sided form for an *asymmetric* range `lo ≤ N ≤ hi` with both endpoints in `(−r, r)` — used by
+Sapling, whose unsigned note values give an asymmetric `vSum` range. -/
+theorem natAbs_lt_of_bounds {r : ℕ} {N lo hi : ℤ}
+    (hlo : lo ≤ N) (hhi : N ≤ hi) (hrlo : -(r : ℤ) < lo) (hrhi : hi < (r : ℤ)) :
+    N.natAbs < r := by
+  have h : |N| < (r : ℤ) := abs_lt.mpr ⟨lt_of_lt_of_le hrlo hlo, lt_of_le_of_lt hhi hrhi⟩
+  rw [Int.abs_eq_natAbs] at h
+  exact_mod_cast h
 
 end Zcash.Security.BindingSignature

--- a/Zcash/Security/BindingSignature/Balance.lean
+++ b/Zcash/Security/BindingSignature/Balance.lean
@@ -234,27 +234,43 @@ theorem bundle_mod_balances (V R : M) (spends outputs : List (F × F)) (vBalance
   value_coeff_zero V R (bindingVK V R spends outputs vBalance) _ _ bsk hbind hExtract
     (bindingVK_decomp V R spends outputs vBalance)
 
-/-- **Integer value balance** — the second stage of the spec §4.13 / §4.14 argument. Stage 1
-(`bundle_mod_balances`) gives `A = 0` in `ZMod r`, i.e. balance *modulo the scalar-field order*. When
-that `A` is the reduction of an integer net value `N = vSum` that cannot wrap (`|N| < r`), the range /
-no-overflow lift `intBalance_eq_zero_of_lt` upgrades it to `N = 0` over ℤ — genuine integer value
-balance. The bound `|N| < r` is the `hbound` hypothesis here; what justifies it is the spec's range
-argument — the unsigned-64-bit note values / signed-64-bit `valueBalance` together with the
-spend/output/action-count bound put `vSum ∈ ValueCommitType ⊂ (−r, r)`. The per-pool lemmas
-`orchard_natAbs_lt` / `sapling_natAbs_lt` (modules `…BindingSignature.Orchard` / `.Sapling`) establish
-this bound from the value-type range proofs, producing the `hbound` consumed here. -/
+/-- Cast an integer-valued bundle (integer note / net values, field randomness) to a field-valued one,
+sending each value `v : ℤ` to its image `(v : ZMod r)` in the value commitment. -/
+def castBundle {r : ℕ} (l : List (ℤ × ZMod r)) : List (ZMod r × ZMod r) :=
+  l.map fun p => ((p.1 : ZMod r), p.2)
+
+/-- The value-sum of a cast bundle is the `ZMod r` image of the integer value-sum, because `Int.cast`
+is additive. This is what lets the integer↔field cast be *derived* rather than assumed. -/
+theorem castBundle_fst_sum {r : ℕ} (l : List (ℤ × ZMod r)) :
+    ((castBundle l).map Prod.fst).sum = (((l.map Prod.fst).sum : ℤ) : ZMod r) := by
+  induction l with
+  | nil => simp [castBundle]
+  | cons a t ih =>
+    simp only [castBundle, List.map_cons, List.sum_cons, Int.cast_add] at ih ⊢
+    rw [ih]
+
+/-- **Integer value balance** — stage 2 of the spec §4.13 / §4.14 argument, over a bundle whose values
+are the actual integer note / net values (`ℤ`), with field randomness. Stage 1 (`bundle_mod_balances`,
+on the cast bundle) gives balance *modulo the scalar-field order*; the no-overflow lift
+`intBalance_eq_zero_of_lt` upgrades it to integer balance `∑ v_in − ∑ v_out − vBalance = 0` over ℤ. The
+integer→field cast is **derived** (`castBundle_fst_sum`), so there is no `hcast` hypothesis: the only
+added input is the no-overflow bound `hbound`, supplied per-pool by `orchard_natAbs_lt` /
+`sapling_natAbs_lt` (modules `…BindingSignature.Orchard` / `.Sapling`) from the value-type range
+proofs. -/
 theorem bundle_integer_balances {r : ℕ} [Fact (Nat.Prime r)]
     {M : Type*} [AddCommGroup M] [Module (ZMod r) M]
-    (V R : M) (spends outputs : List (ZMod r × ZMod r)) (vBalance bsk : ZMod r) (N : ℤ)
-    (hcast : (spends.map Prod.fst).sum - (outputs.map Prod.fst).sum - vBalance = (N : ZMod r))
-    (hbound : N.natAbs < r)
+    (V R : M) (spends outputs : List (ℤ × ZMod r)) (vBalance : ℤ) (bsk : ZMod r)
+    (hbound : ((spends.map Prod.fst).sum - (outputs.map Prod.fst).sum - vBalance).natAbs < r)
     (hbind : Binding (F := ZMod r) V R)
-    (hExtract : bindingVK V R spends outputs vBalance = bsk • R) :
-    N = 0 := by
+    (hExtract : bindingVK V R (castBundle spends) (castBundle outputs) (vBalance : ZMod r) = bsk • R) :
+    (spends.map Prod.fst).sum - (outputs.map Prod.fst).sum - vBalance = 0 := by
   haveI : NeZero r := ⟨(Fact.out : Nat.Prime r).pos.ne'⟩
-  refine intBalance_eq_zero_of_lt N ?_ hbound
-  rw [← hcast]
-  exact bundle_mod_balances V R spends outputs vBalance bsk hbind hExtract
+  refine intBalance_eq_zero_of_lt _ ?_ hbound
+  have hmod := bundle_mod_balances V R (castBundle spends) (castBundle outputs) (vBalance : ZMod r)
+    bsk hbind hExtract
+  rw [castBundle_fst_sum, castBundle_fst_sum] at hmod
+  rw [Int.cast_sub, Int.cast_sub]
+  exact hmod
 
 /-! ### Generic integer-range helpers for the no-overflow lift
 

--- a/Zcash/Security/BindingSignature/Balance.lean
+++ b/Zcash/Security/BindingSignature/Balance.lean
@@ -12,27 +12,28 @@ value-commitment groups. Here `F` will be instantiated with the scalar field `ZM
 
 Value commitments are `cv v rcv = v • V + rcv • R` for fixed generators `V` (value base) and
 `R` (randomness base). For a bundle, the binding verification key is
-`bvk = (∑ spend cv) − (∑ output cv) − v_balance • V`, which by homomorphicity equals
+`bvk = (∑ spend cv) − (∑ output cv) − v_balance • V`. By the module structure that equals
 `A • V + B • R`, where `A = ∑ v_in − ∑ v_out − v_balance` and `B = ∑ rcv_in − ∑ rcv_out`.
 
 ## How binding is expressed (and why not as "no relation exists")
 
 In a prime-order group, `V` and `R` are *always* discrete-log-related — a nontrivial `(a,b)` with
-`a • V + b • R = 0` exists; you simply cannot *find* it. So the information-theoretic statement
-"the only relation is trivial" is **false** in the group setting and must not be used as the
-binding hypothesis. Instead we phrase binding as a **reduction**:
+`a • V + b • R = 0` exists; you simply cannot find it. So the information-theoretic statement
+"the only relation is trivial" is *false* in the group setting and must not be used as the
+binding hypothesis. Instead we phrase binding as a reduction:
 
-* `§ Group-faithful` below proves, with *no* cryptographic hypothesis, that a non-balancing
+* `§ Binding reduction` below proves, with no cryptographic hypothesis, that a non-balancing
   verifying bundle **exhibits** an explicit nontrivial relation between `V` and `R`
   (`relation_of_imbalance`), equivalently the discrete log `dlog_R V` (`rand_log_of_imbalance`).
-  "The bundle balances" is then the *contrapositive under discrete-log-relation hardness* — a
+
+  "The bundle balances" is then the contrapositive under discrete-log-relation hardness — a
   statement about efficient adversaries, supplied by the algebraic group model or a DLR-hardness
   assumption at the computational layer. This is the shape of the spec's argument: *if you can
   unbalance, you can solve DL.*
 
 * `§ Abstract model` keeps the information-theoretic `Binding` predicate, but only as a sanity
   check over a *general* `F`-module where `V, R` genuinely can be independent (e.g. a rank-≥2 free
-  module). It is **not** the group assumption and is never instantiated at a prime-order group.
+  module).
 
 ## Assumptions / later steps
 
@@ -44,9 +45,7 @@ binding hypothesis. Instead we phrase binding as a **reduction**:
   range / no-overflow lift `intBalance_eq_zero_of_lt`, valid when `|vSum| < r`. That bound follows from
   the 64-bit value/balance types and the spend/output/action-count bound; the per-pool lemmas
   `orchard_natAbs_lt` / `sapling_natAbs_lt` (modules `Orchard` / `Sapling`) establish it (see also
-  `§ Integer balance` below). The open step is the plumbing: wiring those lemmas, and the
-  integer→scalar-field cast `hcast`, into `bundle_integer_balances` so the value-type hypotheses are
-  consumed end-to-end.
+  `§ Integer balance` below).
 -/
 
 namespace Zcash.Security.BindingSignature
@@ -64,13 +63,14 @@ theorem smul_value_eq_smul_rand (V R bvk : M) (A B bsk : F)
   calc A • V = bsk • R - B • R := eq_sub_of_add_eq h
     _ = (bsk - B) • R := (sub_smul bsk B R).symm
 
-/-! ### Group-faithful reduction (no cryptographic hypothesis; true in a prime-order group) -/
+/-! ### Binding reduction -/
 
-/-- **The group-faithful binding reduction.** A non-balancing (`A ≠ 0`) verifying bundle *exhibits*
-an explicit nontrivial discrete-log relation between the value base `V` and the randomness base `R`:
-the coefficients `(A, B − bsk)` are not both zero (indeed `A ≠ 0`) and `A • V + (B − bsk) • R = 0`.
-Such a relation always exists in the group; the content is that imbalance *produces* one — which,
-under discrete-log-relation hardness, cannot happen, so the bundle balances. -/
+/-- A non-balancing (`A ≠ 0`) verifying bundle exhibits an explicit nontrivial discrete-log
+elation between the value base `V` and the randomness base `R`: the coefficients `(A, B − bsk)`
+are not both zero (indeed `A ≠ 0`) and `A • V + (B − bsk) • R = 0`.
+
+Such a relation always exists in the group; the content is that imbalance *produces* one.
+Under discrete-log-relation hardness, that cannot happen, so the bundle balances. -/
 theorem relation_of_imbalance (V R bvk : M) (A B bsk : F)
     (hA : A ≠ 0)
     (hExtract : bvk = bsk • R) (hSum : bvk = A • V + B • R) :
@@ -252,11 +252,11 @@ theorem castBundle_fst_sum {r : ℕ} (l : List (ℤ × ZMod r)) :
 /-- **Integer value balance** — stage 2 of the spec §4.13 / §4.14 argument, over a bundle whose values
 are the actual integer note / net values (`ℤ`), with field randomness. Stage 1 (`bundle_mod_balances`,
 on the cast bundle) gives balance *modulo the scalar-field order*; the no-overflow lift
-`intBalance_eq_zero_of_lt` upgrades it to integer balance `∑ v_in − ∑ v_out − vBalance = 0` over ℤ. The
-integer→field cast is **derived** (`castBundle_fst_sum`), so there is no `hcast` hypothesis: the only
-added input is the no-overflow bound `hbound`, supplied per-pool by `orchard_natAbs_lt` /
-`sapling_natAbs_lt` (modules `…BindingSignature.Orchard` / `.Sapling`) from the value-type range
-proofs. -/
+`intBalance_eq_zero_of_lt` upgrades it to integer balance `∑ v_in − ∑ v_out − vBalance = 0` over ℤ.
+
+The integer→field cast is derived using `castBundle_fst_sum`: the only added input is the no-overflow
+bound `hbound`, supplied per-pool by `orchard_natAbs_lt` / `sapling_natAbs_lt` (modules
+`BindingSignature.{Orchard,Sapling}`) from the value-type range proofs. -/
 theorem bundle_integer_balances {r : ℕ} [Fact (Nat.Prime r)]
     {M : Type*} [AddCommGroup M] [Module (ZMod r) M]
     (V R : M) (spends outputs : List (ℤ × ZMod r)) (vBalance : ℤ) (bsk : ZMod r)

--- a/Zcash/Security/BindingSignature/Orchard.lean
+++ b/Zcash/Security/BindingSignature/Orchard.lean
@@ -1,0 +1,51 @@
+import Zcash.Security.BindingSignature.Balance
+
+/-!
+# Orchard no-overflow bound (spec §4.14)
+
+The Orchard action count is bounded *directly* by a dedicated consensus rule `n ≤ 2^16 − 1`,
+independent of the transaction size (the spec notes this is technically redundant given the 2 MB
+limit, but it stands on its own — the elegant case). Each action commits to the signed *net* value
+`v = v_spend − v_output`, range-proven by the Action statement to lie in
+`SignedValueDifferenceType = [−2^64+1, 2^64−1]`, i.e. `|v| ≤ 2^64 − 1`.
+
+This module instantiates the generic `natAbs_lt_of_abs_le` from `Balance` at those concrete bounds,
+discharging the `hbound` hypothesis of `bundle_integer_balances` for Orchard.
+-/
+
+namespace Zcash.Security.BindingSignature
+
+/-- The Pallas scalar field order `r_ℙ` — the order of the Pallas group, which is the scalar field of
+the Orchard value commitment (spec § Pallas and Vesta). -/
+def pallasScalarOrder : ℕ := 0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001
+
+/-- The Orchard `vSum` magnitude bound = the spec's `ValueCommitTypeOrchard` subrange endpoint:
+`(2^16 − 1)·(2^64 − 1) + 2^63`, from `|v| ≤ 2^64 − 1` per action and the consensus rule `n ≤ 2^16 − 1`
+(plus the signed-64-bit `vBalance`). -/
+def orchardVSumBound : ℤ := (2^16 - 1) * (2^64 - 1) + 2^63
+
+/-- The bound equals the spec's quoted endpoint. -/
+example : orchardVSumBound = 1208916596242592319864833 := by norm_num [orchardVSumBound]
+
+/-- **Orchard no-overflow bound.** With `|v| ≤ 2^64 − 1` per action, `n ≤ 2^16 − 1` actions, and
+`|vBalance| ≤ 2^63`, the net sum `vSum = ∑ v − vBalance` has `vSum.natAbs < r` once
+`orchardVSumBound < r`. This is the `hbound` of `bundle_integer_balances` for Orchard. -/
+theorem orchard_natAbs_lt {r : ℕ} (vs : List ℤ) (vBalance : ℤ)
+    (hv : ∀ v ∈ vs, |v| ≤ 2^64 - 1)
+    (hn : vs.length ≤ 2^16 - 1)
+    (hvb : |vBalance| ≤ 2^63)
+    (hr : orchardVSumBound < (r : ℤ)) :
+    (vs.sum - vBalance).natAbs < r := by
+  refine natAbs_lt_of_abs_le ?_ hr
+  have hlen : (vs.length : ℤ) ≤ 2^16 - 1 := by norm_num at hn ⊢; exact_mod_cast hn
+  have hs : |vs.sum| ≤ (2^16 - 1) * (2^64 - 1) :=
+    le_trans (abs_listSum_le hv) (mul_le_mul_of_nonneg_right hlen (by norm_num))
+  calc |vs.sum - vBalance| ≤ |vs.sum| + |vBalance| := abs_sub _ _
+    _ ≤ (2^16 - 1) * (2^64 - 1) + 2^63 := add_le_add hs hvb
+    _ = orchardVSumBound := by norm_num [orchardVSumBound]
+
+/-- The gap holds for the Pallas scalar field, so `orchard_natAbs_lt` is not vacuous. -/
+example : orchardVSumBound < (pallasScalarOrder : ℤ) := by
+  norm_num [orchardVSumBound, pallasScalarOrder]
+
+end Zcash.Security.BindingSignature

--- a/Zcash/Security/BindingSignature/Sapling.lean
+++ b/Zcash/Security/BindingSignature/Sapling.lean
@@ -1,0 +1,185 @@
+import Zcash.Security.BindingSignature.Balance
+
+/-!
+# Sapling no-overflow bound (spec §4.13)
+
+Sapling note values are *unsigned* 64-bit (`ValueType = {0..2^64−1}`), so the `vSum` range is
+**asymmetric**. The action counts are bounded *indirectly* by the 2 MB transaction-size limit (a
+transaction cannot exceed the maximum block size of `2000000` bytes) against the minimum size of each
+description. We reproduce those minimum sizes by summing the encoded field sizes (spec § Spend
+Description Encoding and Consensus / § Output Description Encoding and Consensus) so a reviewer can
+check them, and — as the spec does — we treat **both** v4 and v5 transactions: a v4 Spend carries a
+per-spend `anchor` (32 bytes) that a v5 Spend omits (it is shared once per transaction), so the
+minimum Spend size is 384 bytes (v4) or 352 (v5).
+
+All magnitudes are named constants so no literal is duplicated; each is tied to the spec's quoted
+value by a single `example`. This module discharges the `hbound` of `bundle_integer_balances` for
+Sapling, via `sapling_natAbs_lt` (general) and the `_v4` / `_v5` corollaries.
+-/
+
+namespace Zcash.Security.BindingSignature
+
+/-- The Jubjub scalar field order `ℓ` — the prime-order subgroup order, which is the scalar field of
+the Sapling value commitment (spec § Jubjub). -/
+def jubjubScalarOrder : ℕ := 0x0e7db4ea6533afa906673b0101343b00a6682093ccc81082d0970e5ed6f72cb7
+
+/-- Maximum transaction size in bytes: a transaction cannot exceed the maximum block size
+(`2000000` bytes, a consensus rule). -/
+def maxTxBytes : ℕ := 2000000
+
+/-- Minimum bytes of a Sapling **v4** Spend description (spec § Spend Description Encoding). -/
+def saplingSpendBytesV4 : ℕ :=
+  32 +    -- cv            byte[32]
+  32 +    -- anchor        byte[32]   (per-spend in v4)
+  32 +    -- nullifier     byte[32]
+  32 +    -- rk            byte[32]
+  192 +   -- zkproof       byte[192]
+  64      -- spendAuthSig  byte[64]
+
+/-- Minimum bytes a Sapling Spend contributes to a **v5** transaction. The `zkproof` (192) and
+`spendAuthSig` (64) move to per-spend transaction-level vectors (`vSpendProofsSapling`,
+`vSpendAuthSigs`) but are still counted once per spend; only the `anchor` (32) becomes shared across
+the transaction, so the per-spend minimum is `384 − 32 = 352`. -/
+def saplingSpendBytesV5 : ℕ :=
+  32 +    -- cv            byte[32]
+  32 +    -- nullifier     byte[32]
+  32 +    -- rk            byte[32]
+  192 +   -- zkproof       byte[192]  (in vSpendProofsSapling, per spend)
+  64      -- spendAuthSig  byte[64]   (in vSpendAuthSigs, per spend)
+
+/-- Minimum bytes of a Sapling Output description (spec § Output Description Encoding); identical for
+v4 and v5 (the v5 `zkproof` moves to `vOutputProofsSapling` but stays per-output). -/
+def saplingOutputBytes : ℕ :=
+  32 +    -- cv             byte[32]
+  32 +    -- cmu            byte[32]
+  32 +    -- ephemeralKey   byte[32]
+  580 +   -- encCiphertext  byte[580]
+  80 +    -- outCiphertext  byte[80]
+  192     -- zkproof        byte[192]
+
+example : saplingSpendBytesV4 = 384 := by norm_num [saplingSpendBytesV4]
+example : saplingSpendBytesV5 = 352 := by norm_num [saplingSpendBytesV5]
+example : saplingOutputBytes = 948 := by norm_num [saplingOutputBytes]
+
+/-- Maximum number of Spend descriptions in a v4 transaction: `⌊maxTxBytes / 384⌋`. -/
+def saplingMaxSpendsV4 : ℕ := maxTxBytes / saplingSpendBytesV4
+
+/-- Maximum number of Spend descriptions in a v5 transaction: `⌊maxTxBytes / 352⌋`. -/
+def saplingMaxSpendsV5 : ℕ := maxTxBytes / saplingSpendBytesV5
+
+/-- Maximum number of Output descriptions (either version): `⌊maxTxBytes / 948⌋`. -/
+def saplingMaxOutputs : ℕ := maxTxBytes / saplingOutputBytes
+
+example : saplingMaxSpendsV4 = 5208 := by norm_num [saplingMaxSpendsV4, maxTxBytes, saplingSpendBytesV4]
+example : saplingMaxSpendsV5 = 5681 := by norm_num [saplingMaxSpendsV5, maxTxBytes, saplingSpendBytesV5]
+example : saplingMaxOutputs = 2109 := by norm_num [saplingMaxOutputs, maxTxBytes, saplingOutputBytes]
+
+/-- Spend count from the byte budget: `n` spends of `≥ size` bytes fit in `≤ maxTxBytes` only if
+`n ≤ maxTxBytes / size`. -/
+theorem sapling_spend_count_v4 (n : ℕ) (h : saplingSpendBytesV4 * n ≤ maxTxBytes) :
+    n ≤ saplingMaxSpendsV4 := by
+  simp only [saplingSpendBytesV4, saplingMaxSpendsV4, maxTxBytes] at h ⊢; omega
+
+theorem sapling_spend_count_v5 (n : ℕ) (h : saplingSpendBytesV5 * n ≤ maxTxBytes) :
+    n ≤ saplingMaxSpendsV5 := by
+  simp only [saplingSpendBytesV5, saplingMaxSpendsV5, maxTxBytes] at h ⊢; omega
+
+theorem sapling_output_count (m : ℕ) (h : saplingOutputBytes * m ≤ maxTxBytes) :
+    m ≤ saplingMaxOutputs := by
+  simp only [saplingOutputBytes, saplingMaxOutputs, maxTxBytes] at h ⊢; omega
+
+/-- The Sapling `vSum` upper endpoint as a function of the spend bound: `nspend·(2^64 − 1) + 2^63`
+(spends maximal, outputs zero, `vBalance` minimal). -/
+def saplingVSumUpper (nspend : ℕ) : ℤ := (nspend : ℤ) * (2^64 - 1) + 2^63
+
+/-- The Sapling `vSum` lower endpoint (shared by v4 and v5, since the output count is the same):
+`−saplingMaxOutputs·(2^64 − 1) − 2^63 + 1` (spends zero, outputs maximal, `vBalance` maximal). -/
+def saplingVSumLower : ℤ := -((saplingMaxOutputs : ℤ) * (2^64 - 1)) - 2^63 + 1
+
+/-- The endpoints match the spec's quoted v4/v5 range `[−38913406623490299131842, …]`. -/
+example : saplingVSumLower = -38913406623490299131842 := by
+  norm_num [saplingVSumLower, saplingMaxOutputs, saplingOutputBytes, maxTxBytes]
+
+example : saplingVSumUpper saplingMaxSpendsV4 = 96079866507916199586728 := by
+  norm_num [saplingVSumUpper, saplingMaxSpendsV4, saplingSpendBytesV4, maxTxBytes]
+
+example : saplingVSumUpper saplingMaxSpendsV5 = 104805176454780817500623 := by
+  norm_num [saplingVSumUpper, saplingMaxSpendsV5, saplingSpendBytesV5, maxTxBytes]
+
+/-- **Sapling no-overflow bound (general).** Spend/output values are *unsigned*, range-proven to
+`0 ≤ v ≤ 2^64 − 1`; there are `≤ nspend` spends and `≤ saplingMaxOutputs` outputs (with
+`saplingMaxOutputs ≤ nspend`); and `vBalance` is signed 64-bit. The unsigned values make the range
+asymmetric, `vSum ∈ [saplingVSumLower, saplingVSumUpper nspend]`, so `vSum.natAbs < r` once `r` exceeds
+the (dominating) upper endpoint. The `v4` / `v5` corollaries instantiate `nspend`. -/
+theorem sapling_natAbs_lt {r : ℕ} (olds news : List ℤ) (vBalance : ℤ) (nspend : ℕ)
+    (hold : ∀ v ∈ olds, 0 ≤ v ∧ v ≤ 2^64 - 1)
+    (hnew : ∀ v ∈ news, 0 ≤ v ∧ v ≤ 2^64 - 1)
+    (hno : olds.length ≤ nspend)
+    (hmo : news.length ≤ saplingMaxOutputs)
+    (hns : saplingMaxOutputs ≤ nspend)
+    (hvb : -2^63 ≤ vBalance ∧ vBalance ≤ 2^63 - 1)
+    (hr : saplingVSumUpper nspend < (r : ℤ)) :
+    (olds.sum - news.sum - vBalance).natAbs < r := by
+  have ho_lo : 0 ≤ olds.sum := List.sum_nonneg fun v hv => (hold v hv).1
+  have hn_lo : 0 ≤ news.sum := List.sum_nonneg fun v hv => (hnew v hv).1
+  have ho_hi : olds.sum ≤ (nspend : ℤ) * (2^64 - 1) := by
+    have habs : |olds.sum| ≤ (olds.length : ℤ) * (2^64 - 1) :=
+      abs_listSum_le fun v hv =>
+        abs_le.mpr ⟨by linarith [(hold v hv).1, show (0:ℤ) ≤ 2^64 - 1 by norm_num], (hold v hv).2⟩
+    calc olds.sum ≤ |olds.sum| := le_abs_self _
+      _ ≤ (olds.length : ℤ) * (2^64 - 1) := habs
+      _ ≤ (nspend : ℤ) * (2^64 - 1) := mul_le_mul_of_nonneg_right (by exact_mod_cast hno) (by norm_num)
+  have hn_hi : news.sum ≤ (saplingMaxOutputs : ℤ) * (2^64 - 1) := by
+    have habs : |news.sum| ≤ (news.length : ℤ) * (2^64 - 1) :=
+      abs_listSum_le fun v hv =>
+        abs_le.mpr ⟨by linarith [(hnew v hv).1, show (0:ℤ) ≤ 2^64 - 1 by norm_num], (hnew v hv).2⟩
+    calc news.sum ≤ |news.sum| := le_abs_self _
+      _ ≤ (news.length : ℤ) * (2^64 - 1) := habs
+      _ ≤ (saplingMaxOutputs : ℤ) * (2^64 - 1) :=
+          mul_le_mul_of_nonneg_right (by exact_mod_cast hmo) (by norm_num)
+  refine natAbs_lt_of_bounds (lo := saplingVSumLower) (hi := saplingVSumUpper nspend) ?_ ?_ ?_ hr
+  · simp only [saplingVSumLower]; linarith [ho_lo, hn_hi, hvb.2]
+  · simp only [saplingVSumUpper]; linarith [ho_hi, hn_lo, hvb.1]
+  · simp only [saplingVSumLower]
+    have hmul : (saplingMaxOutputs : ℤ) * (2^64 - 1) ≤ (nspend : ℤ) * (2^64 - 1) :=
+      mul_le_mul_of_nonneg_right (by exact_mod_cast hns) (by norm_num)
+    have hru : (nspend : ℤ) * (2^64 - 1) + 2^63 < (r : ℤ) := by simpa only [saplingVSumUpper] using hr
+    linarith [hru, hmul]
+
+/-- **Sapling v4**: feed the spend/output *byte* budgets (from the 2 MB limit), derive the counts
+(`n ≤ 5208`, `m ≤ 2109`), and conclude `vSum.natAbs < r` once `r` exceeds the v4 endpoint
+`saplingVSumUpper saplingMaxSpendsV4` (= `96079866507916199586728`). -/
+theorem sapling_natAbs_lt_v4 {r : ℕ} (olds news : List ℤ) (vBalance : ℤ)
+    (hold : ∀ v ∈ olds, 0 ≤ v ∧ v ≤ 2^64 - 1)
+    (hnew : ∀ v ∈ news, 0 ≤ v ∧ v ≤ 2^64 - 1)
+    (hspend : saplingSpendBytesV4 * olds.length ≤ maxTxBytes)
+    (houtput : saplingOutputBytes * news.length ≤ maxTxBytes)
+    (hvb : -2^63 ≤ vBalance ∧ vBalance ≤ 2^63 - 1)
+    (hr : saplingVSumUpper saplingMaxSpendsV4 < (r : ℤ)) :
+    (olds.sum - news.sum - vBalance).natAbs < r :=
+  sapling_natAbs_lt olds news vBalance saplingMaxSpendsV4 hold hnew
+    (sapling_spend_count_v4 _ hspend) (sapling_output_count _ houtput)
+    (by norm_num [saplingMaxOutputs, saplingMaxSpendsV4, saplingOutputBytes, saplingSpendBytesV4, maxTxBytes])
+    hvb hr
+
+/-- **Sapling v5**: as v4 but with the smaller v5 Spend size, giving `n ≤ 5681` and the v5 endpoint
+`saplingVSumUpper saplingMaxSpendsV5` (= `104805176454780817500623`). -/
+theorem sapling_natAbs_lt_v5 {r : ℕ} (olds news : List ℤ) (vBalance : ℤ)
+    (hold : ∀ v ∈ olds, 0 ≤ v ∧ v ≤ 2^64 - 1)
+    (hnew : ∀ v ∈ news, 0 ≤ v ∧ v ≤ 2^64 - 1)
+    (hspend : saplingSpendBytesV5 * olds.length ≤ maxTxBytes)
+    (houtput : saplingOutputBytes * news.length ≤ maxTxBytes)
+    (hvb : -2^63 ≤ vBalance ∧ vBalance ≤ 2^63 - 1)
+    (hr : saplingVSumUpper saplingMaxSpendsV5 < (r : ℤ)) :
+    (olds.sum - news.sum - vBalance).natAbs < r :=
+  sapling_natAbs_lt olds news vBalance saplingMaxSpendsV5 hold hnew
+    (sapling_spend_count_v5 _ hspend) (sapling_output_count _ houtput)
+    (by norm_num [saplingMaxOutputs, saplingMaxSpendsV5, saplingOutputBytes, saplingSpendBytesV5, maxTxBytes])
+    hvb hr
+
+/-- Both Sapling upper endpoints fit the Jubjub scalar field, so the corollaries are not vacuous (the
+shared lower magnitude is smaller, so it fits too). -/
+example : saplingVSumUpper saplingMaxSpendsV5 < (jubjubScalarOrder : ℤ) := by
+  norm_num [saplingVSumUpper, saplingMaxSpendsV5, saplingSpendBytesV5, maxTxBytes, jubjubScalarOrder]
+
+end Zcash.Security.BindingSignature


### PR DESCRIPTION
Formalizes the algebraic core of the Zcash binding-signature *balance* soundness argument (protocol spec §4.13 Sapling / §4.14 Orchard), abstracted over an arbitrary `F`-module so that it will be applicable to both the Jubjub (Sapling) and Pallas (Orchard) value-commitment groups.

## Design

- **Abstract `F`-module** route; instantiate `F := ZMod r` later.
- **RedDSA assumed** (extractability), not proved — the balance argument is ROM-free; proving RedDSA would need a random oracle + forking.
- **Binding expressed as a reduction, not info-theoretic independence.** The latter (`∀ a b, a•V + b•R = 0 → a=0 ∧ b=0`) is false in a prime-order group; "balance" is the contrapositive under discrete-log-relation hardness (AGM / DLR layer).
- **Field balance first, then the integer lift** — matching §4.13 / §4.14: the whole $\mathcal{V}$ / $\mathcal{R}$/`F` chain concludes balance *modulo the scalar-field order*; only `bundle_integer_balances` (via `intBalance_eq_zero_of_lt`) upgrades that to integer balance.

## Relation to the spec (§4.13 / §4.14)

The development follows the pencil-and-paper argument in the spec step for step. The correspondence:

| This formalization | Spec §4.13 (Sapling) / §4.14 (Orchard) |
|---|---|
| `V`, `R` | value base $\mathcal{V}$, randomness base $\mathcal{R}$ |
| `valueCommit V R v rcv` | $\mathsf{ValueCommit}_{\mathsf{rcv}}(v) = [v] \mathcal{V} + [\mathsf{rcv}] \mathcal{R}$ |
| `bindingVK` | $\mathsf{bvk}$, the binding validating key (recomputed by validators) |
| `bsk` | $\mathsf{BindingPrivate}$, the binding signing key |
| `bindingVK_decomp` | the expansion $\mathsf{bvk} = [\mathsf{vSum}] \mathcal{V} + [\mathsf{bsk}] \mathcal{R} = \mathsf{ValueCommit}_{\mathsf{bsk}}(\mathsf{vSum})$ |
| `hExtract : bvk = bsk • R` | "a binding signature proves knowledge of the discrete log $\mathsf{bsk}$ of $\mathsf{bvk}$ w.r.t. $\mathcal{R}$" |
| `A` (stage 1) / `N = vSum` (stage 2) | $\mathsf{vSum} = \sum v_{\text{in}} - \sum v_{\text{out}} - \mathsf{vBalance}$ |
| `relation_of_imbalance` → `bundle_mod_balances` | "if $\mathsf{vSum} \neq 0 \pmod r$ then $(\mathsf{vSum}, \mathsf{bsk})$ and $(0, \mathsf{bsk}')$ are distinct openings, breaking binding" ⟹ $\mathsf{vSum} = 0 \pmod r$ |
| `intBalance_eq_zero_of_lt` | $\mathsf{vSum}$ does not overflow $\mathsf{ValueCommitType}$ ⟹ $\mathsf{vSum} = 0$ over $\mathbb{Z}$ |

The **two stages** are the spec's two steps: the algebraic core (through `bundle_mod_balances`) gives balance *modulo the scalar-field order* $r$; the range / no-overflow lift (`intBalance_eq_zero_of_lt`) upgrades it to integer balance — exactly the spec's "the preceding argument shows only that $\mathsf{vSum} = 0 \pmod r$; … we will also demonstrate that it does not overflow $\mathsf{ValueCommitType}$".

The no-overflow bound (currently **assumed**, as `hbound`) is justified in the spec by the value *types*, **not** by `MAX_MONEY` — the argument deliberately works for any signed-64-bit `valueBalance`:

- **Sapling (§4.13):** spend/output values are range-proven unsigned 64-bit ($\mathsf{ValueType} = \{0 \mathbin{..} 2^{64}-1\}$) and $\mathsf{valueBalance}$ is signed 64-bit, giving $\mathsf{vSum} \in [-m(2^{64}-1) - 2^{63} + 1, n(2^{64}-1) + 2^{63}]$; the 2 MB transaction-size limit bounds the action count *indirectly* — $n \leq \lfloor 2000000/352 \rfloor = 5681$ spends, $m \leq \lfloor 2000000/948 \rfloor = 2109$ outputs.
- **Orchard (§4.14):** each action commits to a *net* value $v_{\mathsf{net}} = v_{\mathsf{spend}} - v_{\mathsf{output}}$ (a difference of two unsigned 64-bit note values), range-proven to $\mathsf{SignedValueDifferenceType} = [-2^{64}+1, 2^{64}-1]$ (signed, unlike Sapling's per-note $\mathsf{ValueType}$); so $\mathsf{vSum} \in [-n(2^{64}-1) - 2^{63} + 1, n(2^{64}-1) + 2^{63}]$ (a *single* $n$, as each action contributes one net term). Here the action count is bounded *directly* by a dedicated consensus rule $n \leq 2^{16}-1$, independent of block size — more elegant than Sapling's size-derived bound (the spec notes this rule is technically redundant given the 2 MB limit, but it suffices on its own).

Either way $\mathsf{vSum} \in \mathsf{ValueCommitType} \subset (-r, r)$, so $\mathsf{vSum} = 0 \pmod r$ forces $\mathsf{vSum} = 0$. Formalizing this range derivation — rather than assuming `hbound` — is the remaining piece of the integer stage.

## Guide to `Zcash/Security/BindingSignature/Balance.lean`

- `smul_value_eq_smul_rand` — from RedDSA extractability ($\mathsf{bvk} = \mathsf{bsk} • \mathcal{R}$) and the homomorphic decomposition `hSum :` $\mathsf{bvk} = A • \mathcal{V} + B • \mathcal{R}$, the value coefficient satisfies $A • \mathcal{V} = (\mathsf{bsk} - B) • \mathcal{R}$.
- `relation_of_imbalance` — a non-balancing verifying bundle (with $A \neq 0$) exhibits an explicit nontrivial relation between the value and randomness bases.
- `rand_log_of_imbalance` — the equivalent explicit $\mathsf{dlog}_{\mathcal{R}} \mathcal{V} = A^{-1} (\mathsf{bsk} - B)$ form.
- `valueCommit` / `sum_valueCommit` — the homomorphic value commitment $\mathsf{cv} v \mathsf{rcv} = v • \mathcal{V} + \mathsf{rcv} • \mathcal{R}$, and that a sum of commitments splits as (value-sum) $• \mathcal{V}$ + (randomness-sum) $• \mathcal{R}$.
- `bindingVK_decomp` — the bundle's binding key $\mathsf{bvk} = (\sum \mathsf{spend} \mathsf{cv}) - (\sum \mathsf{output} \mathsf{cv}) - \mathsf{vBalance} • \mathcal{V}$ decomposes as $A • \mathcal{V} + B • \mathcal{R}$, so `hSum` is derived, not assumed.
- `bundle_mod_balances` — *stage 1*: under binding + extractability, a verifying bundle balances **in the scalar field** ($A = 0$ in `ZMod r`).
- `intBalance_eq_zero_of_lt` / `_abs_lt` — the range / no-overflow lift: balance modulo the scalar-field order ⟹ integer balance, when $|\mathsf{vSum}| < r$ (assumed here as the `hbound`/`hlt` hypothesis; see *Relation to the spec* below for why it holds — and that this range derivation is not itself formalized).
- `bundle_integer_balances` — *stage 2*: composing stage 1 with the lift gives integer value balance ($N = 0$ over $\mathbb{Z}$) under the no-wrap bound — the two-stage shape of §4.13 / §4.14.
- A fenced abstract-model `Binding` sanity check (valid only where $\mathcal{V}$, $\mathcal{R}$ can be independent; never instantiated at the group).

Wired into the library build at `Zcash/Security.lean`.

## Notes

- Rebased onto the `v4.30.0-rc2` toolchain bump (#3, now merged); the full library builds clean on 4.30 with no churn in this PR's modules.
- Next: the AGM / DLR wrapper consuming `relation_of_imbalance` against discrete-log-relation hardness; and internalizing the integer→scalar-field cast in `bundle_integer_balances` (currently passed as the `hcast` hypothesis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
